### PR TITLE
Sneaking will use the default breaking speed

### DIFF
--- a/src/bspkrs/treecapitator/fml/PlayerHandler.java
+++ b/src/bspkrs/treecapitator/fml/PlayerHandler.java
@@ -1,6 +1,7 @@
 package bspkrs.treecapitator.fml;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumMovingObjectType;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraftforge.event.ForgeSubscribe;
@@ -14,21 +15,31 @@ import bspkrs.treecapitator.TreeRegistry;
 import bspkrs.util.BlockID;
 import bspkrs.util.CommonUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class PlayerHandler
 {
+    private Map<String, Boolean> playerSneakingMapping = new HashMap<String, Boolean>();
+    
     @ForgeSubscribe
     public void onBlockClicked(PlayerInteractEvent event)
     {
-        if (TCSettings.allowDebugOutput && event.action.equals(PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) && TreeCapitatorMod.proxy.isEnabled() && event.entityPlayer.isSneaking())
+        if (event.action.equals(PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) && TreeCapitatorMod.proxy.isEnabled())
         {
-            Block block = Block.blocksList[event.entityPlayer.worldObj.getBlockId(event.x, event.y, event.z)];
-            
-            if (block != null)
+            if (TCSettings.allowDebugOutput && event.entityPlayer.isSneaking())
             {
-                int metadata = event.entityPlayer.worldObj.getBlockMetadata(event.x, event.y, event.z);
+                Block block = Block.blocksList[event.entityPlayer.worldObj.getBlockId(event.x, event.y, event.z)];
                 
-                TreeCapitatorMod.proxy.debugOutputBlockID(block.blockID, metadata);
+                if (block != null)
+                {
+                    int metadata = event.entityPlayer.worldObj.getBlockMetadata(event.x, event.y, event.z);
+                    
+                    TreeCapitatorMod.proxy.debugOutputBlockID(block.blockID, metadata);
+                }
             }
+            
+            playerSneakingMapping.put(event.entityPlayer.getEntityName(), event.entityPlayer.isSneaking());
         }
     }
     
@@ -36,21 +47,29 @@ public class PlayerHandler
     public void getPlayerBreakSpeed(BreakSpeed event)
     {
         BlockID blockID = new BlockID(event.block.blockID, event.metadata);
+        EntityPlayer player = event.entityPlayer;
         
         if (TreeCapitatorMod.proxy.isEnabled() && TreeRegistry.instance().isRegistered(blockID) &&
-                TreeCapitator.isAxeItemEquipped(event.entityPlayer))
+                TreeCapitator.isAxeItemEquipped(player))
         {
             TreeDefinition treeDef = TreeRegistry.instance().get(blockID);
             if (treeDef != null)
             {
                 if (TCSettings.treeHeightDecidesBreakSpeed)
                 {
-                    MovingObjectPosition thing = CommonUtils.getPlayerLookingSpot(event.entityPlayer, true);
+                    MovingObjectPosition thing = CommonUtils.getPlayerLookingSpot(player, true);
                     if (thing != null && thing.typeOfHit == EnumMovingObjectType.TILE)
                     {
-                        int height = TreeCapitator.getTreeHeight(treeDef, event.entityPlayer.worldObj, thing.blockX, thing.blockY, thing.blockZ, event.metadata, event.entityPlayer);
-                        if (height > 1)
-                            event.newSpeed = event.originalSpeed / (height * 2);
+                        if ((playerSneakingMapping.containsKey(player.getEntityName()) && (playerSneakingMapping.get(player.getEntityName()) == player.isSneaking())) || !playerSneakingMapping.containsKey(player.getEntityName()))
+                        {
+                            if (TreeCapitator.isBreakingEnabled(player)) {
+                                int height = TreeCapitator.getTreeHeight(treeDef, player.worldObj, thing.blockX, thing.blockY, thing.blockZ, event.metadata, player);
+                                if (height > 1)
+                                    event.newSpeed = event.originalSpeed / (height * 2);
+                            }
+                        }
+                        else
+                            event.newSpeed = 0.001f;
                     }
                 }
                 else


### PR DESCRIPTION
Sneaking (or standing, depending on the settings) will now have the default breaking speed. Changing stances will "pause" the breaking of logs by setting the speed low enough until the player goes back to the previous stance.
