### PR TITLE
Make BlockID default, rather than ModulusBlockID. And update Thaumcraft config

### DIFF
--- a/src/main/java/bspkrs/treecapitator/forge/ForgeEventHandler.java
+++ b/src/main/java/bspkrs/treecapitator/forge/ForgeEventHandler.java
@@ -21,7 +21,7 @@ import bspkrs.treecapitator.registry.ModConfigRegistry;
 import bspkrs.treecapitator.registry.TreeDefinition;
 import bspkrs.treecapitator.registry.TreeRegistry;
 import bspkrs.treecapitator.util.TCLog;
-import bspkrs.util.ModulusBlockID;
+import bspkrs.util.BlockID;
 
 import com.google.common.base.Charsets;
 import com.google.common.hash.HashFunction;
@@ -46,7 +46,7 @@ public class ForgeEventHandler
     @SubscribeEvent
     public void getPlayerBreakSpeed(BreakSpeed event)
     {
-        ModulusBlockID blockID = new ModulusBlockID(event.state, 4);
+        BlockID blockID = new BlockID(event.state);
         BlockPos pos = event.pos;
 
         if (TreecapitatorMod.proxy.isEnabled() && (TreeRegistry.instance().isRegistered(blockID)
@@ -101,7 +101,7 @@ public class ForgeEventHandler
         {
             if (TreecapitatorMod.proxy.isEnabled() && !event.world.isRemote)
             {
-                ModulusBlockID blockID = new ModulusBlockID(event.state, 4);
+                BlockID blockID = new BlockID(event.state);
 
                 if ((TreeRegistry.instance().isRegistered(blockID) || (TCSettings.allowAutoTreeDetection
                         && TreeRegistry.canAutoDetect(event.world, event.state.getBlock(), event.pos)))

--- a/src/main/java/bspkrs/treecapitator/registry/ModConfigRegistry.java
+++ b/src/main/java/bspkrs/treecapitator/registry/ModConfigRegistry.java
@@ -407,12 +407,13 @@ public class ModConfigRegistry
         //                "", true).setOverrideIMC(false));
 
         defaultModCfgs.put("Thaumcraft", new ThirdPartyModConfig("Thaumcraft")
-                .addAxe(new ItemID("Thaumcraft:ItemAxeThaumium"))
-                .addAxe(new ItemID("Thaumcraft:ItemAxeElemental"))
+                .addAxe(new ItemID("thaumcraft:thaumium_axe"))
+                .addAxe(new ItemID("thaumcraft:void_axe"))
+                .addAxe(new ItemID("thaumcraft:elemental_axe"))
                 .setOverrideIMC(false)
-                .addTreeDef("greatwood", new TreeDefinition().addLogID(new ModulusBlockID("Thaumcraft:blockMagicalLog", 0, 4)).addLeafID(new ModulusBlockID("Thaumcraft:blockMagicalLeaves", 0, 8))
+                .addTreeDef("greatwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 0)).addLogID(new BlockID("thaumcraft:log", 1)).addLogID(new BlockID("thaumcraft:log", 2)).addLeafID(new BlockID("thaumcraft:leaf", 0))
                         .setMaxHorLeafBreakDist(7).setRequireLeafDecayCheck(false))
-                .addTreeDef("silverwood", new TreeDefinition().addLogID(new ModulusBlockID("Thaumcraft:blockMagicalLog", 1, 4)).addLeafID(new ModulusBlockID("Thaumcraft:blockMagicalLeaves", 1, 8))));
+                .addTreeDef("silverwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 3)).addLogID(new BlockID("thaumcraft:log", 4)).addLogID(new BlockID("thaumcraft:log", 5)).addLeafID(new BlockID("thaumcraft:leaf", 1))));
 
         defaultModCfgs.put("TConstruct", new ThirdPartyModConfig("TConstruct")
                 .addAxe(new ItemID("TConstruct:hatchet"))


### PR DESCRIPTION
Using ModulusBlockID with a modulus of 4 can mess up non-standard log
blocks (like Thaumcraft 5 logs - Greatwood is log:0 through log:2, and
Silverwood is log:3 through log:5) And I updated the Thaumcraft default
config so it works with Thaumcraft 5
