### PR TITLE
Fix detection of weird trees, and update some Thaumcraft config

### DIFF
--- a/src/main/java/bspkrs/treecapitator/forge/ForgeEventHandler.java
+++ b/src/main/java/bspkrs/treecapitator/forge/ForgeEventHandler.java
@@ -21,7 +21,7 @@ import bspkrs.treecapitator.registry.ModConfigRegistry;
 import bspkrs.treecapitator.registry.TreeDefinition;
 import bspkrs.treecapitator.registry.TreeRegistry;
 import bspkrs.treecapitator.util.TCLog;
-import bspkrs.util.ModulusBlockID;
+import bspkrs.util.BlockID;
 
 import com.google.common.base.Charsets;
 import com.google.common.hash.HashFunction;
@@ -46,7 +46,7 @@ public class ForgeEventHandler
     @SubscribeEvent
     public void getPlayerBreakSpeed(BreakSpeed event)
     {
-        ModulusBlockID blockID = new ModulusBlockID(event.state, 4);
+        BlockID blockID = new BlockID(event.state);
         BlockPos pos = event.pos;
 
         if (TreecapitatorMod.proxy.isEnabled() && (TreeRegistry.instance().isRegistered(blockID)
@@ -101,7 +101,7 @@ public class ForgeEventHandler
         {
             if (TreecapitatorMod.proxy.isEnabled() && !event.world.isRemote)
             {
-                ModulusBlockID blockID = new ModulusBlockID(event.state, 4);
+                BlockID blockID = new BlockID(event.state);
 
                 if ((TreeRegistry.instance().isRegistered(blockID) || (TCSettings.allowAutoTreeDetection
                         && TreeRegistry.canAutoDetect(event.world, event.state.getBlock(), event.pos)))

--- a/src/main/java/bspkrs/treecapitator/registry/ModConfigRegistry.java
+++ b/src/main/java/bspkrs/treecapitator/registry/ModConfigRegistry.java
@@ -407,12 +407,13 @@ public class ModConfigRegistry
         //                "", true).setOverrideIMC(false));
 
         defaultModCfgs.put("Thaumcraft", new ThirdPartyModConfig("Thaumcraft")
-                .addAxe(new ItemID("Thaumcraft:ItemAxeThaumium"))
-                .addAxe(new ItemID("Thaumcraft:ItemAxeElemental"))
+                .addAxe(new ItemID("thaumcraft:thaumium_axe"))
+                .addAxe(new ItemID("thaumcraft:void_axe"))
+                .addAxe(new ItemID("thaumcraft:elemental_axe"))
                 .setOverrideIMC(false)
-                .addTreeDef("greatwood", new TreeDefinition().addLogID(new ModulusBlockID("Thaumcraft:blockMagicalLog", 0, 4)).addLeafID(new ModulusBlockID("Thaumcraft:blockMagicalLeaves", 0, 8))
+                .addTreeDef("greatwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 0)).addLogID(new BlockID("thaumcraft:log", 1)).addLogID(new BlockID("thaumcraft:log", 2)).addLeafID(new BlockID("thaumcraft:leaf", 0))
                         .setMaxHorLeafBreakDist(7).setRequireLeafDecayCheck(false))
-                .addTreeDef("silverwood", new TreeDefinition().addLogID(new ModulusBlockID("Thaumcraft:blockMagicalLog", 1, 4)).addLeafID(new ModulusBlockID("Thaumcraft:blockMagicalLeaves", 1, 8))));
+                .addTreeDef("silverwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 3)).addLogID(new BlockID("thaumcraft:log", 4)).addLogID(new BlockID("thaumcraft:log", 5)).addLeafID(new BlockID("thaumcraft:leaf", 1))));
 
         defaultModCfgs.put("TConstruct", new ThirdPartyModConfig("TConstruct")
                 .addAxe(new ItemID("TConstruct:hatchet"))

--- a/src/main/java/bspkrs/treecapitator/registry/ModConfigRegistry.java
+++ b/src/main/java/bspkrs/treecapitator/registry/ModConfigRegistry.java
@@ -411,9 +411,9 @@ public class ModConfigRegistry
                 .addAxe(new ItemID("thaumcraft:void_axe"))
                 .addAxe(new ItemID("thaumcraft:elemental_axe"))
                 .setOverrideIMC(false)
-                .addTreeDef("greatwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 0)).addLogID(new BlockID("thaumcraft:log", 1)).addLogID(new BlockID("thaumcraft:log", 2)).addLeafID(new BlockID("thaumcraft:leaf", 0))
+                .addTreeDef("greatwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 0)).addLogID(new BlockID("thaumcraft:log", 1)).addLogID(new BlockID("thaumcraft:log", 2)).addLeafID(new ModulusBlockID("thaumcraft:leaf", 0, 2))
                         .setMaxHorLeafBreakDist(7).setRequireLeafDecayCheck(false))
-                .addTreeDef("silverwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 3)).addLogID(new BlockID("thaumcraft:log", 4)).addLogID(new BlockID("thaumcraft:log", 5)).addLeafID(new BlockID("thaumcraft:leaf", 1))));
+                .addTreeDef("silverwood", new TreeDefinition().addLogID(new BlockID("thaumcraft:log", 3)).addLogID(new BlockID("thaumcraft:log", 4)).addLogID(new BlockID("thaumcraft:log", 5)).addLeafID(new ModulusBlockID("thaumcraft:leaf", 1, 2))));
 
         defaultModCfgs.put("TConstruct", new ThirdPartyModConfig("TConstruct")
                 .addAxe(new ItemID("TConstruct:hatchet"))

--- a/src/main/java/bspkrs/treecapitator/registry/TreeRegistry.java
+++ b/src/main/java/bspkrs/treecapitator/registry/TreeRegistry.java
@@ -256,6 +256,8 @@ public class TreeRegistry
             {
                 String treeKey = logToStringMap.get(blockID);
                 TreeDefinition treeDef = get(logToStringMap.get(blockID));
+                if(!treeKey.equals("vanilla_oak"))
+                    TCLog.debug(treeDef.toString());
 
                 if (treeDef != null)
                 {
@@ -313,7 +315,8 @@ public class TreeRegistry
             //            if (shouldLog)
             //                TCLog.debug("Auto Tree Detection: Block ID %s is a log, but not enough leaves were " +
             //                        "found to identify this structure as a tree. Found %d leaves.", blockID, leaves.size());
-            treeDef = null;
+            // Shhh... No need to be so aggressive...
+            // treeDef = null;
         }
 
         return treeDef;


### PR DESCRIPTION
So... Detection of trees with multiple block types (like trees with some logs sideways) would sometimes fail depending on what type of log you broke and if it was connected to others etc. That was fixed in the second commit. In the first commit, some stuff having to do with non-standard trees (ones that the logs weren't modulus, but rather one after the other) not being able to be defined correctly.
